### PR TITLE
Add initialDelaySeconds and Increase Readiness Probe timeoutSeconds

### DIFF
--- a/resources/petclinic.yaml
+++ b/resources/petclinic.yaml
@@ -43,6 +43,7 @@ spec:
             path: /
             port: 8080
             scheme: HTTP
+          initialDelaySeconds: 45
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
@@ -60,9 +61,10 @@ spec:
             path: /
             port: 8080
             scheme: HTTP
+          initialDelaySeconds: 45
           periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 1
+          timeoutSeconds: 5
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
@@ -107,7 +109,7 @@ spec:
     deploymentconfig: spring-petclinic
   sessionAffinity: None
   type: ClusterIP
----  
+---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:


### PR DESCRIPTION
Closes #8 

This pull request adds an `initialDelaySeconds` property set to 45 seconds for the readiness and liveness probes of the Spring PetClinic sample application. It also increases the `timeoutSeconds` from 1 to 5 for the `readinessProbe`. 

These changes allows the Spring PetClinic to app to be properly deployed to the `pipelines-tutorial` project as part of this tutorial without issue. 

The `initialDelaySeconds` property allows the Spring PetClinic application enough time to start up on its container. 45 seconds was chosen based on how long the applications takes to start:

```
2019-07-08 02:12:29.346  INFO 1 --- [           main] o.s.s.petclinic.PetClinicApplication     : Started PetClinicApplication in 33.888 seconds (JVM running for 36.885)
```

The `timeoutSeconds` property was raised to address the following: 

```
Unhealthy	Readiness probe failed: Get http://10.24.1.33:8080/: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

The decision to pick 5 seconds was based on reading through this [issue](https://github.com/kubernetes/kubernetes/issues/51096).