### PR TITLE
Add more information in demo script

### DIFF
--- a/demo
+++ b/demo
@@ -17,8 +17,13 @@ _log() {
     echo -e "$level: $@"
 }
 
+
 log.err() {
     _log "ERROR" "$@" >&2
+}
+
+info() {
+    _log "\nINFO" "$@"
 }
 
 err() {
@@ -52,18 +57,42 @@ demo.prep() {
   oc adm policy add-role-to-user edit -z pipeline
 }
 
-TEKTON_CATALOG="https://raw.githubusercontent.com/tektoncd/catalog/master"
-OPENSHIFT_CATALOG="https://raw.githubusercontent.com/openshift/pipelines-catalog/master"
+declare -r TEKTON_CATALOG="https://raw.githubusercontent.com/tektoncd/catalog/master"
+declare -r OPENSHIFT_CATALOG="https://raw.githubusercontent.com/openshift/pipelines-catalog/master"
+declare -r TASKS_DIR=tmp/tasks
+
+declare -r OC_TASK="$TEKTON_CATALOG/openshift-client/openshift-client-task.yaml"
+declare -r LOCAL_OC_TASK="$TASKS_DIR/oc.task.yaml"
+
+declare -r S2I_JAVA8_TASK="$OPENSHIFT_CATALOG/s2i-java-8/s2i-java-8-task.yaml"
+declare -r LOCAL_S2I_JAVA8_TASK="$TASKS_DIR/s2i-java8.task.yaml"
+
+demo.get-tasks() {
+  echo Downloading tasks from catalog into $TASKS_DIR directory
+  mkdir -p "$TASKS_DIR"
+  curl -sLf  "$S2I_JAVA8_TASK" -o "$LOCAL_S2I_JAVA8_TASK"
+  curl -sLf  "$OC_TASK" -o "$LOCAL_OC_TASK"
+}
 
 
 demo.setup() {
+  demo.get-tasks
+
+  info "Apply petclinic resources"
   oc apply -f resources/petclinic.yaml
 
-  oc apply -f "$TEKTON_CATALOG/openshift-client/openshift-client-task.yaml"
-  oc apply -f "$OPENSHIFT_CATALOG/s2i-java-8/s2i-java-8-task.yaml"
+  info "Apply pipeline tasks"
+  oc apply -f "$TASKS_DIR"
+
+  info "Applying resources"
   oc apply -f resources/petclinic-resources.yaml
+
+  info "Applying pipeline"
   oc apply -f resources/petclinic-deploy-pipeline.yaml
-  tkn p ls
+
+  echo -e "\nPipeline"
+  echo "==============="
+  tkn p desc petclinic-deploy-pipeline
 }
 
 demo.logs() {
@@ -82,14 +111,13 @@ demo.run() {
 
 demo.help() {
   cat <<-EOF
-USAGE: 
- demo [command]
+		USAGE:
+		  demo [command]
 
-COMMANDS:
- prep           creates project and service account
- setup          creates tasks, pipeline and resources
- run            starts pipeline
-
+		COMMANDS:
+		  prep      creates project and service account
+		  setup     creates tasks, pipeline and resources
+		  run       starts pipeline
 EOF
 
 }
@@ -97,7 +125,10 @@ EOF
 
 main() {
   local fn="demo.${1:-help}"
-  valid_command "$fn" || err  1 "invalid command $1"
+  valid_command "$fn" || {
+    demo.help
+    err  1 "invalid command '$1'"
+  }
 
   cd $SCRIPT_DIR
   $fn "$@"

--- a/demo
+++ b/demo
@@ -36,30 +36,23 @@ execute() {
   ${DRY_RUN:-false} || "$@"
 }
 
-#mask oc and tkn to use the $NAMESPACE
+# helpers to avoid adding -n $NAMESPACE to oc and tkn
 OC() {
+  echo oc -n ${NAMESPACE} "$@"
   oc -n ${NAMESPACE} "$@"
 }
 
 TKN() {
+ echo tkn -n ${NAMESPACE} "$@"
  tkn -n ${NAMESPACE} "$@"
 }
 
 demo.validate() {
+  info "validating tools"
+
   tkn version >/dev/null 2>&1 || err 1 "no tkn binary found"
   oc version >/dev/null 2>&1 || err 1 "no oc binary found"
   return 0
-}
-
-demo.prep() {
-  demo.validate
-  oc get ns "$NAMESPACE" 2>/dev/null  || {
-    oc new-project $NAMESPACE
-  }
-
-  OC get sa pipeline || OC create serviceaccount pipeline
-  OC adm policy add-scc-to-user privileged -z pipeline
-  OC adm policy add-role-to-user edit -z pipeline
 }
 
 declare -r TEKTON_CATALOG="https://raw.githubusercontent.com/tektoncd/catalog/master"
@@ -73,7 +66,7 @@ declare -r S2I_JAVA8_TASK="$OPENSHIFT_CATALOG/s2i-java-8/s2i-java-8-task.yaml"
 declare -r LOCAL_S2I_JAVA8_TASK="$TASKS_DIR/s2i-java8.task.yaml"
 
 demo.get-tasks() {
-  echo Downloading tasks from catalog into $TASKS_DIR directory
+  info "Downloading tasks from catalog to $TASKS_DIR directory"
   mkdir -p "$TASKS_DIR"
   curl -sLf  "$S2I_JAVA8_TASK" -o "$LOCAL_S2I_JAVA8_TASK"
   curl -sLf  "$OC_TASK" -o "$LOCAL_OC_TASK"
@@ -81,6 +74,19 @@ demo.get-tasks() {
 
 
 demo.setup() {
+  demo.validate
+
+
+  info "ensure namespace $NAMESPACE exists"
+  OC get ns "$NAMESPACE" 2>/dev/null  || {
+    OC new-project $NAMESPACE
+  }
+
+  info "setup required service accounts"
+  OC get sa pipeline || OC create serviceaccount pipeline
+  OC adm policy add-scc-to-user privileged -z pipeline
+  OC adm policy add-role-to-user edit -z pipeline
+
   demo.get-tasks
 
   info "Apply petclinic resources"
@@ -120,9 +126,9 @@ demo.help() {
 		  demo [command]
 
 		COMMANDS:
-		  prep      creates project and service account
-		  setup     creates tasks, pipeline and resources
+		  setup     setups project, tasks, pipeline and resources
 		  run       starts pipeline
+		  logs      show logs of last pipelinerun
 EOF
 
 }

--- a/demo
+++ b/demo
@@ -3,14 +3,7 @@ set -e -u -o pipefail
 
 declare -r SCRIPT_DIR=$(cd -P $(dirname $0) && pwd)
 
-must_exist() {
-  local path="$1"; shift
-  [[ -r "$path" ]] || {
-    echo "Missing file $path"
-    exit 1
-  }
-  return 0
-}
+declare -r NAMESPACE=${NAMESPACE:-pipelines-tutorial}
 
 _log() {
     local level=$1; shift
@@ -33,11 +26,6 @@ err() {
     exit $code
 }
 
-log.debug() {
-    _log DEBUG "$@"
-}
-
-
 valid_command() {
   local fn=$1; shift
   [[ $(type -t "$fn") == "function" ]]
@@ -48,13 +36,29 @@ execute() {
   ${DRY_RUN:-false} || "$@"
 }
 
+#mask oc and tkn to use the $NAMESPACE
+OC() {
+  oc -n ${NAMESPACE} "$@"
+}
+
+TKN() {
+ tkn -n ${NAMESPACE} "$@"
+}
+
+demo.validate() {
+  tkn version >/dev/null 2>&1 || err 1 "no tkn binary found"
+  oc version >/dev/null 2>&1 || err 1 "no oc binary found"
+  return 0
+}
+
 demo.prep() {
-  oc get ns -o name | grep -q namespace/pipelines-tutorial || {
-    oc new-project pipelines-tutorial
+  demo.validate
+  oc get ns "$NAMESPACE" 2>/dev/null  || {
+    oc new-project $NAMESPACE
   }
-  oc create serviceaccount pipeline
-  oc adm policy add-scc-to-user privileged -z pipeline
-  oc adm policy add-role-to-user edit -z pipeline
+  OC create serviceaccount pipeline
+  OC adm policy add-scc-to-user privileged -z pipeline
+  OC adm policy add-role-to-user edit -z pipeline
 }
 
 declare -r TEKTON_CATALOG="https://raw.githubusercontent.com/tektoncd/catalog/master"
@@ -79,28 +83,28 @@ demo.setup() {
   demo.get-tasks
 
   info "Apply petclinic resources"
-  oc apply -f resources/petclinic.yaml
+  OC apply -f resources/petclinic.yaml
 
   info "Apply pipeline tasks"
-  oc apply -f "$TASKS_DIR"
+  OC apply -f "$TASKS_DIR"
 
   info "Applying resources"
-  oc apply -f resources/petclinic-resources.yaml
+  OC apply -f resources/petclinic-resources.yaml
 
   info "Applying pipeline"
-  oc apply -f resources/petclinic-deploy-pipeline.yaml
+  OC apply -f resources/petclinic-deploy-pipeline.yaml
 
   echo -e "\nPipeline"
   echo "==============="
-  tkn p desc petclinic-deploy-pipeline
+  TKN p desc petclinic-deploy-pipeline
 }
 
 demo.logs() {
-  tkn pipeline logs petclinic-deploy-pipeline -l -f
+  TKN pipeline logs petclinic-deploy-pipeline -l -f
 }
 
 demo.run() {
-  tkn pipeline start petclinic-deploy-pipeline \
+  TKN pipeline start petclinic-deploy-pipeline \
     -r app-git=petclinic-git \
     -r app-image=petclinic-image \
     -s pipeline

--- a/demo
+++ b/demo
@@ -56,7 +56,8 @@ demo.prep() {
   oc get ns "$NAMESPACE" 2>/dev/null  || {
     oc new-project $NAMESPACE
   }
-  OC create serviceaccount pipeline
+
+  OC get sa pipeline || OC create serviceaccount pipeline
   OC adm policy add-scc-to-user privileged -z pipeline
   OC adm policy add-role-to-user edit -z pipeline
 }


### PR DESCRIPTION
Changes include:
- removes the `prep` step; combined with setup
- download the tasks that are applied for later reference (useful to inspect and convert to new format)
- Allows the demo namespace to be configurable. e.g. `NAMESPACE=foobar ./demo setup`
- prints help if the command is wrong
- more verbose information about the setup step
- minor whitespace changes

Signed-off-by: Sunil Thaha <sthaha@redhat.com>