### PR TITLE
Added instructions for using the dev console for starting pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,13 @@ Pipelinerun started: petclinic-deploy-pipeline-run-q62p8
 
 The `-r` flag specifies the `PipelineResource`s that should be provided to the pipeline and the `-s` flag specifies the service account to be used for running the pipeline.
 
+> **Note**: OpenShift Pipelines 0.7 does not automatically use the `pipeline` service account for running pipelineruns. This has been fixed in the next release, OpenShift Pipelines 0.8, but if you want to use the OpenShift Console developer perspective to start the pipeline with OpenShift Pipelines 0.7, run the following commands to elevate the permissions of the `default` service account, which is currently used by default for running pipelineruns that are started by the OpenShift Console:  
+>  ```
+>  $ oc create serviceaccount pipeline
+>  $ oc adm policy add-scc-to-user privileged -z pipeline
+>  $ oc adm policy add-role-to-user edit -z pipeline
+>  ```
+
 As soon as you start the `petclinic-deploy-pipeline` pipeline, a pipelinerun will be instantiated and pods will be created to execute the tasks that are defined in the pipeline.
 
 ```bash


### PR DESCRIPTION
Dev Console uses the `default` sa for starting pipelines and without elevating the `default` sa permissions, builds would fail if pipeline starts from the Dev Console. 

This is a temporary fix and should be removed in OpenShift Pipelines 0.8