### PR TITLE
Use new parameters for tekton on tekton

### DIFF
--- a/tekton/run.yaml
+++ b/tekton/run.yaml
@@ -8,9 +8,9 @@ spec:
     name: pipeline-tutorial-check
   params:
     - name: repo_url
-      value: {{repository.html_url}}
+      value: {{repo_url}}
     - name: revision
-      value: {{pull_request.head.sha}}
+      value: {{revision}}
   workspaces:
   - name: source
     volumeClaimTemplate:


### PR DESCRIPTION
We changed the parameters for tekton on tekton, which makes it much more easy
for users to specify for at least the one that are most used coming from the
git_clone task.