### PR TITLE
Fixed typo in Frontend section

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Backend:
 
 Frontend:
 
-  1. Clones the source code of the backend application from a git repository when  (`git-repo` git resource) refered to `ui-repo`
+  1. Clones the source code of the frontend application from a git repository when  (`git-repo` git resource) refered to `ui-repo`
   2. Builds the container image of backend using the `buildah` clustertask
   that uses [Buildah](https://buildah.io/) to build the image
   3. The application image is pushed to an image registry by refering (`image` image resource) to `ui-image`


### PR DESCRIPTION
There was a typo in the `Frontend` section of the `README.md` referring to cloning the `backend` application  from a git repository when refered to `ui-repo`. 

In this particular instance the correct application is actually the `frontend` application.

I corrected the error by changing `backend` to `frontend`.