### PR TITLE
Update demo.sh

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -121,7 +121,7 @@ demo.run() {
   TKN pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=01_pipeline/03_persistent_volume_claim.yaml \
     -p deployment-name=vote-api \
-    -p git-url=http://github.com/openshift-pipelines/vote-api.git \
+    -p git-url=https://github.com/openshift-pipelines/vote-api.git \
     -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-api \
     --showlog=true
 
@@ -129,7 +129,7 @@ demo.run() {
   TKN pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=01_pipeline/03_persistent_volume_claim.yaml \
     -p deployment-name=vote-ui \
-    -p git-url=http://github.com/openshift-pipelines/vote-ui.git \
+    -p git-url=https://github.com/openshift-pipelines/vote-ui.git \
     -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-ui \
     --showlog=true
 


### PR DESCRIPTION
* Updated git-url to use `https` instead  in demo.sh script.

you would experience Below error, with disconnected cluster or cluster with proxy setup:
```
test -z http://ec2-52-14-193-37.us-east-2.compute.amazonaws.com:3128
+ export HTTP_PROXY=http://ec2-52-14-193-37.us-east-2.compute.amazonaws.com:3128
+ HTTP_PROXY=http://ec2-52-14-193-37.us-east-2.compute.amazonaws.com:3128
+ test -z http://ec2-52-14-193-37.us-east-2.compute.amazonaws.com:3128
+ export HTTPS_PROXY=http://ec2-52-14-193-37.us-east-2.compute.amazonaws.com:3128
+ HTTPS_PROXY=http://ec2-52-14-193-37.us-east-2.compute.amazonaws.com:3128
+ test -z test.no-proxy.com
+ export NO_PROXY=test.no-proxy.com
+ NO_PROXY=test.no-proxy.com
+ /ko-app/git-init -url http://github.com/openshift-pipelines/vote-api'' -refspec '' -path /workspace/output/ -sslVerify=true -submodules=true -depth 1
{"level":"error","ts":1611559910.4253728,"caller":"git/git.go:54","msg":"Error running git [fetch --recurse-submodules=yes --depth=1 origin --update-head-ok --force HEAD]: exit status 128\nfatal: unable to access 'http://github.com/openshift-pipelines/vote-api/': Failed to connect to github.com port 80: Connection timed out\n","stacktrace":"github.com/tektoncd/pipeline/pkg/git.run\n\t/opt/app-root/src/go/src/github.com/tektoncd/pipeline/pkg/git/git.go:54\ngithub.com/tektoncd/pipeline/pkg/git.Fetch\n\t/opt/app-root/src/go/src/github.com/tektoncd/pipeline/pkg/git/git.go:145\nmain.main\n\t/opt/app-root/src/go/src/github.com/tektoncd/pipeline/cmd/git-init/main.go:52\nruntime.main\n\t/usr/lib/golang/src/runtime/proc.go:204"}
{"level":"fatal","ts":1611559910.4254596,"caller":"git-init/main.go:53","msg":"Error fetching git repository: failed to fetch [HEAD]: exit status 128","stacktrace":"main.main\n\t/opt/app-root/src/go/src/github.com/tektoncd/pipeline/cmd/git-init/main.go:53\nruntime.main\n\t/usr/lib/golang/src/runtime/proc.go:204"}
```
