### PR TITLE
Pipelines 1.3

### DIFF
--- a/02_pipelinerun/01_build_deploy_api_pipelinerun.yaml
+++ b/02_pipelinerun/01_build_deploy_api_pipelinerun.yaml
@@ -9,7 +9,7 @@ spec:
   - name: deployment-name
     value: vote-api
   - name: git-url
-    value: http://github.com/openshift-pipelines/vote-api.git
+    value: https://github.com/openshift-pipelines/vote-api.git
   - name: IMAGE
     value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-api
   workspaces:

--- a/02_pipelinerun/02_build_deploy_ui_pipelinerun.yaml
+++ b/02_pipelinerun/02_build_deploy_ui_pipelinerun.yaml
@@ -9,7 +9,7 @@ spec:
   - name: deployment-name
     value: vote-ui
   - name: git-url
-    value: http://github.com/openshift-pipelines/vote-ui.git
+    value: https://github.com/openshift-pipelines/vote-ui.git
   - name: IMAGE
     value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-ui
   workspaces:


### PR DESCRIPTION
1. HTTPS is necessary on disconnected clusters
2. this is the only place where we reference these repos using HTTP