### PR TITLE
Update pipelines-1.4 manifests

### DIFF
--- a/02_pipelinerun/01_build_deploy_api_pipelinerun.yaml
+++ b/02_pipelinerun/01_build_deploy_api_pipelinerun.yaml
@@ -7,7 +7,7 @@ spec:
     name: build-and-deploy
   params:
   - name: deployment-name
-    value: vote-api
+    value: pipelines-vote-api
   - name: git-url
     value: https://github.com/openshift/pipelines-vote-api.git
   - name: IMAGE

--- a/02_pipelinerun/01_build_deploy_api_pipelinerun.yaml
+++ b/02_pipelinerun/01_build_deploy_api_pipelinerun.yaml
@@ -11,7 +11,7 @@ spec:
   - name: git-url
     value: https://github.com/openshift/pipelines-vote-api.git
   - name: IMAGE
-    value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-api
+    value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-api
   workspaces:
   - name: shared-workspace
     volumeClaimTemplate:

--- a/02_pipelinerun/02_build_deploy_ui_pipelinerun.yaml
+++ b/02_pipelinerun/02_build_deploy_ui_pipelinerun.yaml
@@ -7,7 +7,7 @@ spec:
     name: build-and-deploy
   params:
   - name: deployment-name
-    value: vote-ui
+    value: pipelines-vote-ui
   - name: git-url
     value: https://github.com/openshift/pipelines-vote-ui.git
   - name: IMAGE

--- a/02_pipelinerun/02_build_deploy_ui_pipelinerun.yaml
+++ b/02_pipelinerun/02_build_deploy_ui_pipelinerun.yaml
@@ -11,7 +11,7 @@ spec:
   - name: git-url
     value: https://github.com/openshift/pipelines-vote-ui.git
   - name: IMAGE
-    value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-ui
+    value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-ui
   workspaces:
   - name: shared-workspace
     volumeClaimTemplate:

--- a/03_triggers/02_template.yaml
+++ b/03_triggers/02_template.yaml
@@ -16,7 +16,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: build-deploy-$(tt.params.git-repo-name)-$(uid)
+      generateName: build-deploy-$(tt.params.git-repo-name)-
     spec:
       serviceAccountName: pipeline
       pipelineRef:

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: build-deploy-$(tt.params.git-repo-name)-$(uid)
+      generateName: build-deploy-$(tt.params.git-repo-name)-
     spec:
       serviceAccountName: pipeline
       pipelineRef:
@@ -623,7 +623,7 @@ $ git commit -m "empty-commit" --allow-empty && git push origin pipelines-1.4
 ...
 Writing objects: 100% (1/1), 190 bytes | 190.00 KiB/s, done.
 Total 1 (delta 0), reused 0 (delta 0)
-To github.com:<github-username>/vote-api.git
+To github.com:<github-username>/pipelines-vote-api.git
    72c14bb..97d3115  pipelines-1.4 -> pipelines-1.4
 ```
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ specified in the pipeline.
 >If you are not into the `pipelines-tutorial` namespace, and using another namespace for the tutorial steps, please make sure you update the
 frontend and backend image resource to the correct url with your namespace name like so :
 >
->`image-registry.openshift-image-registry.svc:5000/<namespace-name>/vote-api:latest`
+>`image-registry.openshift-image-registry.svc:5000/<namespace-name>/pipelines-vote-api:latest`
 
 
 
@@ -333,9 +333,9 @@ Lets start a pipeline to build and deploy backend application using `tkn`:
 ```bash
 $ tkn pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=https://raw.githubusercontent.com/openshift/pipelines-tutorial/pipelines-1.4/01_pipeline/03_persistent_volume_claim.yaml \
-    -p deployment-name=vote-api \
+    -p deployment-name=pipelines-vote-api \
     -p git-url=https://github.com/openshift/pipelines-vote-api.git \
-    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-api \
+    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-api \
 
 Pipelinerun started: build-and-deploy-run-z2rz8
 
@@ -348,9 +348,9 @@ Similarly, start a pipeline to build and deploy frontend application:
 ```bash
 $ tkn pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=https://raw.githubusercontent.com/openshift/pipelines-tutorial/pipelines-1.4/01_pipeline/03_persistent_volume_claim.yaml \
-    -p deployment-name=vote-ui \
+    -p deployment-name=pipelines-vote-ui \
     -p git-url=https://github.com/openshift/pipelines-vote-ui.git \
-    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-ui \
+    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-ui \
 
 Pipelinerun started: build-and-deploy-run-xy7rw
 
@@ -524,11 +524,10 @@ metadata:
   name: vote-trigger
 spec:
   serviceAccountName: pipeline
-  triggers:
-  - bindings:
+  bindings:
     - ref: vote-app
-    template:
-      ref: vote-app
+  template:
+    ref: vote-app
 ```
 
 Run following command to apply Trigger.

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Looking back at the project, you should see that the images are successfully bui
 You can get the route of the application by executing the following command and access the application
 
 ```bash
-$ oc get route vote-ui --template='http://{{.spec.host}}'
+$ oc get route pipelines-vote-ui --template='http://{{.spec.host}}'
 ```
 
 

--- a/demo.sh
+++ b/demo.sh
@@ -120,7 +120,7 @@ demo.run() {
   info "Running API Build and deploy"
   TKN pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=01_pipeline/03_persistent_volume_claim.yaml \
-    -p deployment-name=vote-api \
+    -p deployment-name=pipelines-vote-api \
     -p git-url=https://github.com/openshift/pipelines-vote-api.git \
     -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-api \
     --showlog=true
@@ -128,7 +128,7 @@ demo.run() {
   info "Running UI Build and deploy"
   TKN pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=01_pipeline/03_persistent_volume_claim.yaml \
-    -p deployment-name=vote-ui \
+    -p deployment-name=pipelines-vote-ui \
     -p git-url=https://github.com/openshift/pipelines-vote-ui.git \
     -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-ui \
     --showlog=true

--- a/demo.sh
+++ b/demo.sh
@@ -159,7 +159,7 @@ demo.validate_pipelinerun() {
 
 demo.url() {
   echo "Click following URL to access the application"
-  oc -n "$NAMESPACE" get route vote-ui --template='http://{{.spec.host}} '
+  oc -n "$NAMESPACE" get route pipelines-vote-ui --template='http://{{.spec.host}} '
   echo
 }
 

--- a/demo.sh
+++ b/demo.sh
@@ -122,7 +122,7 @@ demo.run() {
     -w name=shared-workspace,volumeClaimTemplateFile=01_pipeline/03_persistent_volume_claim.yaml \
     -p deployment-name=pipelines-vote-api \
     -p git-url=https://github.com/openshift/pipelines-vote-api.git \
-    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-api \
+    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-api \
     --showlog=true
 
   info "Running UI Build and deploy"
@@ -130,7 +130,7 @@ demo.run() {
     -w name=shared-workspace,volumeClaimTemplateFile=01_pipeline/03_persistent_volume_claim.yaml \
     -p deployment-name=pipelines-vote-ui \
     -p git-url=https://github.com/openshift/pipelines-vote-ui.git \
-    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/vote-ui \
+    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-ui \
     --showlog=true
 
   info "Validating the result of pipeline run"


### PR DESCRIPTION
* Switch to UUID for event IDs ([#926](https://github.com/tektoncd/triggers/pull/926))
* including $uid in pipelinerun name throwing below error
```
couldn't create resource with group version kind \"tekton.dev/v1beta1, Resource=pipelineruns\": admission webhook \"validation.webhook.pipeline.tekton.dev\" denied the request: validation failed: Invalid resource name: length must be no more than 63 characters: metadata.name
```
* so I am replacing triggertemplate to use `generateName`  instead