### PR TITLE
Update triggers object to use v1beta1

### DIFF
--- a/03_triggers/01_binding.yaml
+++ b/03_triggers/01_binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerBinding
 metadata:
   name: vote-app

--- a/03_triggers/02_template.yaml
+++ b/03_triggers/02_template.yaml
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
   name: vote-app

--- a/03_triggers/03_trigger.yaml
+++ b/03_triggers/03_trigger.yaml
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
 metadata:
   name: vote-trigger

--- a/03_triggers/04_event_listener.yaml
+++ b/03_triggers/04_event_listener.yaml
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
   name: vote-app

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ A `TriggerTemplate` is a resource which have parameters that can be substituted 
 The definition of our TriggerTemplate is given in `03_triggers/02-template.yaml`.
 
 ```yaml
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
   name: vote-app
@@ -493,7 +493,7 @@ TriggerBindings is a map enable you to capture fields from an event and store th
 The definition of our TriggerBinding is given in `03_triggers/01_binding.yaml`.
 
 ```yaml
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerBinding
 metadata:
   name: vote-app
@@ -521,7 +521,7 @@ $ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/pi
 The definition of our Trigger is given in `03_triggers/03_trigger.yaml`.
 
 ```yaml
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
 metadata:
   name: vote-trigger
@@ -570,7 +570,7 @@ The definition for our EventListener can be found in
 `03_triggers/04_event_listener.yaml`.
 
 ```yaml
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
   name: vote-app


### PR DESCRIPTION
(cherry picked from commit fda003a5627f1156b2442d9161a84e67f4ded535)
Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

cc @ppitonak 