### PR TITLE
force redeploy application pods

### DIFF
--- a/01_pipeline/02_update_deployment_task.yaml
+++ b/01_pipeline/02_update_deployment_task.yaml
@@ -23,7 +23,7 @@ spec:
             }]
           }}}}'
 
-          # https://issues.redhat.com/browse/SRVKP-2387
+          # issue: https://issues.redhat.com/browse/SRVKP-2387
           # images are deployed with tag. on rebuild of the image tags are not updated, hence redeploy is not happening
           # as a workaround update a label in template, which triggers redeploy pods
           # target label: "spec.template.metadata.labels.patched_at"

--- a/01_pipeline/02_update_deployment_task.yaml
+++ b/01_pipeline/02_update_deployment_task.yaml
@@ -22,3 +22,15 @@ spec:
               "image":"$(inputs.params.IMAGE)"
             }]
           }}}}'
+
+          # https://issues.redhat.com/browse/SRVKP-2387
+          # images are deployed with tag. on rebuild of the image tags are not updated, hence redeploy is not happening
+          # as a workaround update a label in template, which triggers redeploy pods
+          # target label: "spec.template.metadata.labels.patched_at"
+          # NOTE: this workaround works only if the pod spec has imagePullPolicy: Always
+          patched_at_timestamp=`date +%s`
+          oc patch deployment $(inputs.params.deployment) --patch='{"spec":{"template":{"metadata":{
+            "labels":{
+              "patched_at": '\"$patched_at_timestamp\"'
+            }
+          }}}}'


### PR DESCRIPTION
* fixes: https://issues.redhat.com/browse/SRVKP-2387
* in a deployment modifying template `labels` can redeploy the pods. I am taking timestamp and patching a label (`patched_at`) on each build